### PR TITLE
Use `:set paste`?

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -7,7 +7,6 @@ set smartcase
 set hls
 
 " indenting
-" I have a love-hate relationship with AI/SI... if only it really chilled out during pastes
 filetype indent on
 set ai
 set smartindent


### PR DESCRIPTION
Creeping through your dotfiles this morning and noticed you had documented a, perhaps outdated, annoyance. Would using `:set paste` before pasting take care of this annoyance with auto indent?
